### PR TITLE
Bump version to 3.0.0-SNAPSHOT for XP 8

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            2.x
 
   release:
     runs-on: ubuntu-latest

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,4 +5,4 @@ group = com.enonic.app
 projectName = imagexpert
 appName = com.enonic.app.imagexpert
 xpVersion=8.0.0-B4
-version=2.1.1-SNAPSHOT
+version=3.0.0-SNAPSHOT


### PR DESCRIPTION
## Summary

- Bump master `version` from `2.1.1-SNAPSHOT` to `3.0.0-SNAPSHOT` for the XP 8 line.
- Add `releaseBranch:` configuration to `.github/workflows/enonic-gradle.yml` listing both `master` and `2.x`, so CI on either branch is recognised as a release-branch build.
- A companion `2.x` maintenance branch has been created at `d91e57470fe89a4b8ed46fe6c5ed0ac89e7cc7ca` (the post-`v2.1.0` SNAPSHOT commit, `version=2.1.1-SNAPSHOT`). A separate PR against `2.x` adds the same `releaseBranch:` config there (the action reads it from the branch's own workflow file).

Reference: app-booster's `master` / `1.x` split.

## Test plan

- [ ] CI run on `chore/bump-to-next-major` is green.
- [ ] After merge, master's `gradle.properties` reads `version=3.0.0-SNAPSHOT`.
- [ ] After merge + companion `2.x` PR, a push to `2.x` is classified as a release branch by `enonic/release-tools/build-and-publish`.