### PR TITLE
Fix XP 8 runtime issues #46

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,5 +19,5 @@ dependencies {
 
 repositories {
     mavenCentral()
-    xp.enonicRepo()
+    xp.enonicRepo('dev')
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
-mustache = "2.1.1"
-thymeleaf = "2.1.1"
+mustache = "3.0.0-SNAPSHOT"
+thymeleaf = "3.0.0-SNAPSHOT"
 
 [libraries]
 lib-mustache = { module = "com.enonic.lib:lib-mustache", version.ref = "mustache" }

--- a/src/main/resources/cms/pages/image/image.js
+++ b/src/main/resources/cms/pages/image/image.js
@@ -46,7 +46,7 @@ function handleGet(req) {
 
     var view = resolve('image.page.html');
     var body = mustacheLib.render(view, {
-        assetUrl: portalLib.assetUrl(''),
+        assetUrl: portalLib.assetUrl({path: ''}),
         downloadImageServiceUrl: downloadImageServiceUrl,
         updateMetaServiceUrl: portalLib.serviceUrl({service: "update-meta"}),
         imageUrl: imageUrl,

--- a/src/main/resources/cms/pages/main/main.js
+++ b/src/main/resources/cms/pages/main/main.js
@@ -15,7 +15,7 @@ function handleGet(req) {
         searchPageUrl: portal.serviceUrl({service: "search"}),
         loadAlbumsUrl: portal.serviceUrl({service: "load-albums"}),
         deleteServiceUrl: portal.serviceUrl({service: "delete-content"}),
-        assetUrl: portal.assetUrl(''),
+        assetUrl: portal.assetUrl({path: ''}),
         baseUrl: imageXpertLib.generateHomeUrl()
     };
     

--- a/src/main/resources/cms/pages/offline/offline.js
+++ b/src/main/resources/cms/pages/offline/offline.js
@@ -6,7 +6,7 @@ function handleGet(req) {
     var version = req.params.version || 'full';
 
     var params = {
-        assetUrl: portal.assetUrl(''),
+        assetUrl: portal.assetUrl({path: ''}),
         fullVersion: (version == 'full')
     };
     

--- a/src/main/resources/lib/manifest/controller.js
+++ b/src/main/resources/lib/manifest/controller.js
@@ -5,7 +5,7 @@ exports.get = function(req) {
     var sitePath = portalLib.getSite()._path;
     var params = {
         siteUrl : portalLib.pageUrl({path: sitePath}),
-        assetUrl : portalLib.assetUrl('')
+        assetUrl : portalLib.assetUrl({path: ''})
     };
     var res = mustache.render(resolve('manifest.json'), params);
 

--- a/src/main/resources/lib/service-worker/controller.js
+++ b/src/main/resources/lib/service-worker/controller.js
@@ -5,7 +5,7 @@ exports.get = function(req) {
     var sitePath = portalLib.getSite()._path;
     var params = {
         siteUrl : portalLib.pageUrl({path: sitePath}),
-        assetUrl : portalLib.assetUrl(''),
+        assetUrl : portalLib.assetUrl({path: ''}),
         appVersion: app.version
     };
 

--- a/src/main/resources/main.js
+++ b/src/main/resources/main.js
@@ -17,7 +17,8 @@ function runInContext(callback) {
     try {
         result = contextLib.run({
             principals: ["role:system.admin"],
-            repository: 'com.enonic.cms.' + projectData.id
+            repository: 'com.enonic.cms.' + projectData.id,
+            branch: 'draft'
         }, callback);
     } catch (e) {
         log.info('Error: ' + e.message);


### PR DESCRIPTION
Three small XP 8 runtime fixes uncovered by the E2E verification.

## What changed

| File(s) | Change | Reason |
|---|---|---|
| `gradle/libs.versions.toml`, `build.gradle` | `lib-mustache` / `lib-thymeleaf` 2.1.1 → 3.0.0-SNAPSHOT and `xp.enonicRepo('dev')` | XP 8 needs SNAPSHOT versions of these libs (Apache 2.x mustache/thymeleaf 2.x are XP 7 builds). SNAPSHOTs only resolve on `repo.enonic.com/dev`. |
| `src/main/resources/main.js` | Add `branch: 'draft'` to `contextLib.run({...})` | XP 8 requires a branch when the context targets a specific repo. Without it, demo data import throws `Error: branch is required` on first boot. |
| `cms/pages/{main,image,offline}/*.js`, `lib/{manifest,service-worker}/controller.js` | `portal.assetUrl('')` → `portal.assetUrl({path: ''})` | `lib-portal` in XP 8 takes an `AssetUrlParams` object; the legacy string form throws `Parameter 'path' is required`. Empty-string path keeps the templates' `{{assetUrl}}/foo.png` pattern intact (returns a base URL with no trailing slash). |

## Verification

XP 8.0.0-B4 + this PR (commit dc1b8a2):

- Bundle reaches ACTIVE: `Started application com.enonic.app.imagexpert bundle 117`
- Demo content imports cleanly (no `branch is required` error).
- PWA mappings respond 200 with rendered output via vhost to `/site/image-xpert/draft`:
  - `GET /image-xpert/manifest.json` → 200 (valid JSON, asset URLs resolved)
  - `GET /image-xpert/service-worker.js` → 200 (valid JS, asset URLs resolved)
  - `GET /image-xpert/offline` → 200 (HTML)

The album-browsing pages (`/image-xpert`, `/image-xpert/image`) still 500 with `ForbiddenAccessException` for anonymous users — that's a separate project-permissions issue (XP 8 requires explicit `permissions.viewer` on the project, `readAccess.public: true` is no longer sufficient on its own for unauthenticated reads), not in scope for this PR.

Closes #46
