### PR TITLE
Migrate to lib-asset #48

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,7 @@ dependencies {
 
     include libs.lib.mustache
     include libs.lib.thymeleaf
+    include libs.lib.asset
 }
 
 repositories {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,9 @@
 [versions]
 mustache = "3.0.0-SNAPSHOT"
 thymeleaf = "3.0.0-SNAPSHOT"
+asset = "2.0.0-SNAPSHOT"
 
 [libraries]
 lib-mustache = { module = "com.enonic.lib:lib-mustache", version.ref = "mustache" }
 lib-thymeleaf = { module = "com.enonic.lib:lib-thymeleaf", version.ref = "thymeleaf" }
+lib-asset = { module = "com.enonic.lib:lib-asset", version.ref = "asset" }

--- a/src/main/resources/cms/pages/image/image.js
+++ b/src/main/resources/cms/pages/image/image.js
@@ -1,5 +1,6 @@
 var contentLib = require('/lib/xp/content');
 var portalLib = require('/lib/xp/portal');
+var assetLib = require('/lib/enonic/asset');
 var imageXpertLib = require('/lib/image-xpert');
 var mustacheLib = require('/lib/mustache');
 
@@ -46,7 +47,7 @@ function handleGet(req) {
 
     var view = resolve('image.page.html');
     var body = mustacheLib.render(view, {
-        assetUrl: portalLib.assetUrl({path: ''}),
+        assetUrl: assetLib.assetUrl({path: ''}),
         downloadImageServiceUrl: downloadImageServiceUrl,
         updateMetaServiceUrl: portalLib.serviceUrl({service: "update-meta"}),
         imageUrl: imageUrl,

--- a/src/main/resources/cms/pages/main/main.js
+++ b/src/main/resources/cms/pages/main/main.js
@@ -1,4 +1,5 @@
 var portal = require('/lib/xp/portal');
+var assetLib = require('/lib/enonic/asset');
 var imageXpertLib = require('/lib/image-xpert');
 var parentPath = './';
 var view = resolve(parentPath + 'main.page.html');
@@ -15,7 +16,7 @@ function handleGet(req) {
         searchPageUrl: portal.serviceUrl({service: "search"}),
         loadAlbumsUrl: portal.serviceUrl({service: "load-albums"}),
         deleteServiceUrl: portal.serviceUrl({service: "delete-content"}),
-        assetUrl: portal.assetUrl({path: ''}),
+        assetUrl: assetLib.assetUrl({path: ''}),
         baseUrl: imageXpertLib.generateHomeUrl()
     };
     

--- a/src/main/resources/cms/pages/offline/offline.js
+++ b/src/main/resources/cms/pages/offline/offline.js
@@ -1,4 +1,4 @@
-var portal = require('/lib/xp/portal');
+var assetLib = require('/lib/enonic/asset');
 var view = resolve('offline.page.html');
 var mustacheLib = require('/lib/mustache');
 
@@ -6,7 +6,7 @@ function handleGet(req) {
     var version = req.params.version || 'full';
 
     var params = {
-        assetUrl: portal.assetUrl({path: ''}),
+        assetUrl: assetLib.assetUrl({path: ''}),
         fullVersion: (version == 'full')
     };
     

--- a/src/main/resources/cms/site.yaml
+++ b/src/main/resources/cms/site.yaml
@@ -1,4 +1,6 @@
 kind: "Site"
+apis:
+  - "asset"
 mappings:
   - controller: "/cms/pages/image/image.js"
     pattern: "/image"

--- a/src/main/resources/lib/manifest/controller.js
+++ b/src/main/resources/lib/manifest/controller.js
@@ -1,11 +1,12 @@
 var portalLib = require('/lib/xp/portal');
+var assetLib = require('/lib/enonic/asset');
 var mustache = require('/lib/mustache');
 
 exports.get = function(req) {
     var sitePath = portalLib.getSite()._path;
     var params = {
         siteUrl : portalLib.pageUrl({path: sitePath}),
-        assetUrl : portalLib.assetUrl({path: ''})
+        assetUrl : assetLib.assetUrl({path: ''})
     };
     var res = mustache.render(resolve('manifest.json'), params);
 

--- a/src/main/resources/lib/service-worker/controller.js
+++ b/src/main/resources/lib/service-worker/controller.js
@@ -1,11 +1,12 @@
 var portalLib = require('/lib/xp/portal');
+var assetLib = require('/lib/enonic/asset');
 var mustache = require('/lib/mustache');
 
 exports.get = function(req) {
     var sitePath = portalLib.getSite()._path;
     var params = {
         siteUrl : portalLib.pageUrl({path: sitePath}),
-        assetUrl : portalLib.assetUrl({path: ''}),
+        assetUrl : assetLib.assetUrl({path: ''}),
         appVersion: app.version
     };
 


### PR DESCRIPTION
Closes #48.

`portal.assetUrl` is `@deprecated` in lib-portal (*"Use libAsset or libStatic instead. This function will be removed in future versions."*). All five call sites in this app run in the Site context defined by `src/main/resources/cms/site.yaml`, so **lib-asset** is the correct target — lib-static is only needed for admin extensions / id providers / universal APIs, none of which apply here.

## Changes

- `build.gradle` / `gradle/libs.versions.toml` — include `com.enonic.lib:lib-asset:2.0.0-SNAPSHOT`.
- `src/main/resources/cms/site.yaml` — register `apis: ["asset"]` on the Site descriptor (this app's only descriptor that consumes asset URLs).
- Replaced `portal.assetUrl({path: ''})` with `assetLib.assetUrl({path: ''})` in:
  - `src/main/resources/cms/pages/main/main.js`
  - `src/main/resources/cms/pages/image/image.js`
  - `src/main/resources/cms/pages/offline/offline.js`
  - `src/main/resources/lib/manifest/controller.js`
  - `src/main/resources/lib/service-worker/controller.js`

`offline.js` only used `portal.assetUrl`, so its `/lib/xp/portal` import is now removed. The other files still call `portal.serviceUrl` / `portal.pageUrl` / `portal.attachmentUrl` / `portal.getSite`, so they keep the portal import.

## Test plan

- [x] `./gradlew build --refresh-dependencies` clean.
- [x] Inline XP-in-`/tmp` E2E (per `IdeaProjects/CLAUDE.md`): deployed jar, app reached ACTIVE, `image-xpert` project + content auto-imported.
- [x] All five replaced call sites exercised and returned HTTP 200, generating lib-asset URLs of the shape `/site/image-xpert/draft/image-xpert/_/com.enonic.app.imagexpert:asset/<fingerprint>/...`:
  - `GET /site/image-xpert/draft/image-xpert` (main.js page controller)
  - `GET /site/image-xpert/draft/image-xpert/image` (image.js)
  - `GET /site/image-xpert/draft/image-xpert/offline` (offline.js)
  - `GET /site/image-xpert/draft/image-xpert/manifest.json` (manifest controller)
  - `GET /site/image-xpert/draft/image-xpert/service-worker.js` (service-worker controller)
- [x] Sampled the generated asset URLs (CSS / JS / PNG) — all returned HTTP 200 with the expected content-type and non-empty body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)