### PR TITLE
Migrate to XP 8 lib-project API

### DIFF
--- a/src/main/resources/main.js
+++ b/src/main/resources/main.js
@@ -7,9 +7,7 @@ const projectData = {
     id: 'image-xpert',
     displayName: 'Image expert',
     description: 'Image expert project',
-    readAccess: {
-        public: true
-    }
+    publicRead: true
 }
 
 function runInContext(callback) {


### PR DESCRIPTION
## Summary

Flip the project bootstrap literal in `src/main/resources/main.js` from the old `readAccess: { public: true }` nested shape to the new flat `publicRead: true` field, per the breaking change in [enonic/xp#12043](https://github.com/enonic/xp/pull/12043).

This is the only `readAccess`/`modifyReadAccess` call site in the repo (verified by grep). No `projectLib.modify(...)` calls exist, so no editor-function rewrite is needed.

## Reference

- Source PR: [enonic/xp#12043](https://github.com/enonic/xp/pull/12043)
- Upgrade notes: [enonic/doc-code → docs/upgrade.adoc](https://github.com/enonic/doc-code/blob/master/docs/upgrade.adoc) (lib-project section)

## Test plan

- [x] `./gradlew build` green locally
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)