### PR TITLE
Import fix: content.import attr, vacuum skip

### DIFF
--- a/src/main/resources/import/replace_app.xsl
+++ b/src/main/resources/import/replace_app.xsl
@@ -1,33 +1,14 @@
 <?xml version="1.0"?>
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
     <xsl:output method="xml" indent="yes"/>
-    <xsl:param name="applicationId"/>
-    <xsl:variable name="applicationIdDashed" select="translate($applicationId, '.', '-')"/>
-    <xsl:variable name="placeholderApp" select="'com.enonic.app.imagexpert'"/>
-    <xsl:variable name="placeholderAppDashed" select="translate($placeholderApp, '.', '-')"/>
+    <xsl:param name="keepPublishFirst" select="'true'"/>
 
-    <xsl:template match="string[starts-with(text(),concat($placeholderApp,':'))]">
-        <string>
-            <xsl:attribute name="name">
-                <xsl:value-of select="@name"/>
-            </xsl:attribute>
-            <xsl:value-of select="concat($applicationId, substring-after(.,$placeholderApp))"/>
-        </string>
-    </xsl:template>
-
-    <xsl:template match="string[text() = $placeholderApp]">
-        <string>
-            <xsl:attribute name="name">
-                <xsl:value-of select="@name"/>
-            </xsl:attribute>
-            <xsl:value-of select="$applicationId"/>
-        </string>
-    </xsl:template>
-
-    <xsl:template match="property-set/@name[. = $placeholderAppDashed]">
-        <xsl:attribute name="name">
-            <xsl:value-of select="$applicationIdDashed"/>
-        </xsl:attribute>
+    <xsl:template match="data/property-set[@name='publish']">
+        <xsl:if test="$keepPublishFirst != 'false'">
+            <xsl:copy>
+                <xsl:apply-templates select="@*|*[@name='first']"/>
+            </xsl:copy>
+        </xsl:if>
     </xsl:template>
 
     <xsl:template match="@*|node()">
@@ -35,6 +16,4 @@
             <xsl:apply-templates select="@*|node()"/>
         </xsl:copy>
     </xsl:template>
-
-
 </xsl:stylesheet>

--- a/src/main/resources/main.js
+++ b/src/main/resources/main.js
@@ -61,6 +61,13 @@ function createContent() {
         xsltParams: {
             applicationId: app.name
         },
+        versionAttributes: {
+            'content.import': {
+                user: "role:system.admin",
+                optime: new Date().toISOString()
+            },
+            'vacuum.skip': {}
+        },
         includeNodeIds: true
     });
     log.info('-------------------');


### PR DESCRIPTION
## Summary

Mirrors [enonic/app-features#248](https://github.com/enonic/app-features/pull/248) (the canonical fix). Same fix has also been applied to [enonic/app-superhero-blog@dd30922](https://github.com/enonic/app-superhero-blog/commit/dd30922) on master.

Two related improvements to the bootstrap-via-import flow:

- **Drop dead placeholder-app templates from `replace_app.xsl`.** Every demo app sets `placeholderApp` equal to its own `app.name`, so the rewriting templates were no-ops. The XSLT now only cleans publish fields during import (keeping `publish.first`).
- **Add `versionAttributes` to the `importNodes(...)` call** so imported content gets `content.import` (for downstream consumers) and `vacuum.skip` (so vacuum doesn't reclaim it).

## Test plan

- [x] `./gradlew build` clean
- [ ] CI green